### PR TITLE
feat(test): use multiple log dirs in Kafka cluster

### DIFF
--- a/deploy/cruisecontrol/capacityJBOD.json
+++ b/deploy/cruisecontrol/capacityJBOD.json
@@ -3,7 +3,10 @@
     {
       "brokerId": "-1",
       "capacity": {
-        "DISK": "1000000",
+        "DISK": {
+          "/var/lib/kafka/data0": "100000",
+          "/var/lib/kafka/data1": "100000"
+        },
         "CPU": "100",
         "NW_IN": "10000",
         "NW_OUT": "10000"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     volumes:
       - type: volume
         source: kafka_0_data
-        target: /var/lib/kafka/data
+        target: /var/lib/kafka
       - type: volume
         source: kafka_0_secrets
         target: /etc/kafka/secrets

--- a/deploy/kafka/kafka.env
+++ b/deploy/kafka/kafka.env
@@ -8,6 +8,7 @@ KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
 JMX_PORT=9997
 KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=kafka0 -Dcom.sun.management.jmxremote.rmi.port=9997"
 KAFKA_METRIC_REPORTERS=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+KAFKA_LOG_DIRS=/var/lib/kafka/data0,/var/lib/kafka/data1
 
 # cruise.control.metrics.topic.auto.create
 KAFKA_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE=true


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |

### What's in this PR?
Update Kafka cluster configuration used for integration testing to have multiple log directories which allows to perform disk rebalance operation via Cruise Control.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Tested against Cruise Control version: x.y.z (if applicable)
- [x] User guide and development docs updated (if needed)