### PR TITLE
refactor: always return API response

### DIFF
--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -25,175 +25,112 @@ import (
 
 func (c *Client) AddBroker(r *api.AddBrokerRequest) (*api.AddBrokerResponse, error) {
 	resp := &api.AddBrokerResponse{}
-	if err := c.request(r, resp, api.EndpointAddBroker, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointAddBroker, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) Admin(r *api.AdminRequest) (*api.AdminResponse, error) {
 	resp := &api.AdminResponse{}
-	if err := c.request(r, resp, api.EndpointAdmin, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointAdmin, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) Bootstrap(r *api.BootstrapRequest) (*api.BootstrapResponse, error) {
 	resp := &api.BootstrapResponse{}
-	if err := c.request(r, resp, api.EndpointBootstrap, http.MethodGet, 5*time.Minute); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointBootstrap, http.MethodGet, 5*time.Minute)
 }
 
 func (c *Client) DemoteBroker(r *api.DemoteBrokerRequest) (*api.DemoteBrokerResponse, error) {
 	resp := &api.DemoteBrokerResponse{}
-	if err := c.request(r, resp, api.EndpointDemoteBroker, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointDemoteBroker, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) FixOfflineReplicas(r *api.FixOfflineReplicasRequest) (*api.FixOfflineReplicasResponse, error) {
 	resp := &api.FixOfflineReplicasResponse{}
-	if err := c.request(r, resp, api.EndpointFixOfflineReplicas, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointFixOfflineReplicas, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) KafkaClusterLoad(r *api.KafkaClusterLoadRequest) (*api.KafkaClusterLoadResponse, error) {
 	resp := &api.KafkaClusterLoadResponse{}
-	if err := c.request(r, resp, api.EndpointKafkaClusterLoad, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointKafkaClusterLoad, http.MethodGet, DefaultRequestTimeout)
 }
 
 func (c *Client) KafkaClusterState(r *api.KafkaClusterStateRequest) (*api.KafkaClusterStateResponse, error) {
 	resp := &api.KafkaClusterStateResponse{}
-	if err := c.request(r, resp, api.EndpointKafkaClusterState, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointKafkaClusterState, http.MethodGet, DefaultRequestTimeout)
 }
 
 func (c *Client) KafkaPartitionLoad(r *api.KafkaPartitionLoadRequest) (*api.KafkaPartitionLoadResponse, error) {
 	resp := &api.KafkaPartitionLoadResponse{}
-	if err := c.request(r, resp, api.EndpointKafkaPartitionLoad, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointKafkaPartitionLoad, http.MethodGet, DefaultRequestTimeout)
 }
 
 func (c *Client) PauseSampling(r *api.PauseSamplingRequest) (*api.PauseSamplingResponse, error) {
 	resp := &api.PauseSamplingResponse{}
-	if err := c.request(r, resp, api.EndpointPauseSampling, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointPauseSampling, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) Proposals(r *api.ProposalsRequest) (*api.ProposalsResponse, error) {
 	resp := &api.ProposalsResponse{}
-	if err := c.request(r, resp, api.EndpointProposals, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointProposals, http.MethodGet, DefaultRequestTimeout)
 }
 
 func (c *Client) Rebalance(r *api.RebalanceRequest) (*api.RebalanceResponse, error) {
 	resp := &api.RebalanceResponse{}
-	if err := c.request(r, resp, api.EndpointRebalance, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointRebalance, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) RemoveBroker(r *api.RemoveBrokerRequest) (*api.RemoveBrokerResponse, error) {
 	resp := &api.RemoveBrokerResponse{}
-	if err := c.request(r, resp, api.EndpointRemoveBroker, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointRemoveBroker, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) ResumeSampling(r *api.ResumeSamplingRequest) (*api.ResumeSamplingResponse, error) {
 	resp := &api.ResumeSamplingResponse{}
-	if err := c.request(r, resp, api.EndpointResumeSampling, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointResumeSampling, http.MethodPost, DefaultRequestTimeout)
 }
 
 func (c *Client) Review(r *api.ReviewRequest) (*api.ReviewResponse, error) {
 	resp := &api.ReviewResponse{}
-	if err := c.request(r, resp, api.EndpointReview, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointReview, http.MethodPost, DefaultRequestTimeout)
 }
 
 // ReviewBoard returns a list of Cruise Control requests with their review state.
 func (c *Client) ReviewBoard(r *api.ReviewBoardRequest) (*api.ReviewBoardResponse, error) {
 	resp := &api.ReviewBoardResponse{}
-	if err := c.request(r, resp, api.EndpointReviewBoard, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointReviewBoard, http.MethodGet, DefaultRequestTimeout)
 }
 
 // Rightsize allows manually invoke provisioner rightsizing of the cluster.
 func (c *Client) Rightsize(r *api.RightsizeRequest) (*api.RightsizeResponse, error) {
 	resp := &api.RightsizeResponse{}
-	if err := c.request(r, resp, api.EndpointRightsize, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointRightsize, http.MethodPost, DefaultRequestTimeout)
 }
 
 // State reports back the Cruise Control state.
 func (c *Client) State(r *api.StateRequest) (*api.StateResponse, error) {
 	resp := &api.StateResponse{}
-	if err := c.request(r, resp, api.EndpointState, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointState, http.MethodGet, DefaultRequestTimeout)
 }
 
 // StopProposalExecution invoke stopping of ongoing proposal execution in Cruise Control.
 func (c *Client) StopProposalExecution(r *api.StopProposalExecutionRequest) (*api.StopProposalExecutionResponse, error) {
 	resp := &api.StopProposalExecutionResponse{}
-	if err := c.request(r, resp, api.EndpointStopProposalExecution, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointStopProposalExecution, http.MethodPost, DefaultRequestTimeout)
 }
 
 // TopicConfiguration allows changing Kafka topic configuration using Cruise Control.
 func (c *Client) TopicConfiguration(r *api.TopicConfigurationRequest) (*api.TopicConfigurationResponse, error) {
 	resp := &api.TopicConfigurationResponse{}
-	if err := c.request(r, resp, api.EndpointTopicConfiguration, http.MethodPost, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointTopicConfiguration, http.MethodPost, DefaultRequestTimeout)
 }
 
 // Train Cruise Control to better model broker cpu usage.
 func (c *Client) Train(r *api.TrainRequest) (*api.TrainResponse, error) {
 	resp := &api.TrainResponse{}
-	if err := c.request(r, resp, api.EndpointTrain, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointTrain, http.MethodGet, DefaultRequestTimeout)
 }
 
 // UserTasks returns the list of recent tasks performed by Cruise Control.
 func (c *Client) UserTasks(r *api.UserTasksRequest) (*api.UserTasksResponse, error) {
 	resp := &api.UserTasksResponse{}
-	if err := c.request(r, resp, api.EndpointUserTasks, http.MethodGet, DefaultRequestTimeout); err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, c.request(r, resp, api.EndpointUserTasks, http.MethodGet, DefaultRequestTimeout)
 }


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |

### What's in this PR?
Return API response even if the operation failed to make the User-Task-ID available for the requester.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Tested against Cruise Control version: 2.5.80
- [x] User guide and development docs updated (if needed)
