### PR TITLE
Fix for cc 2.5.94+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 It's client library (written in Golang) for interacting with
 [Linkedin Cruise Control](https://github.com/linkedin/cruise-control) using its HTTP API.
 
-Supported _Cruise Control_ versions: **2.5.x** (tested with v2.5.86)
+Supported _Cruise Control_ versions: **2.5.94+ (tested with v2.5.101)
 
 ## How to use it
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 It's client library (written in Golang) for interacting with
 [Linkedin Cruise Control](https://github.com/linkedin/cruise-control) using its HTTP API.
 
-Supported _Cruise Control_ versions: **2.5.94+ (tested with v2.5.101)
+Supported _Cruise Control_ versions: **2.5.94+** (tested with v2.5.101)
 
 ## How to use it
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       retries: 30
 
   cruisecontrolmetrics:
-    image: ghcr.io/banzaicloud/cruise-control:2.5.86
+    image: ghcr.io/banzaicloud/cruise-control:2.5.101
     restart: "on-failure"
     hostname: cruisecontrolmetrics
     container_name: cruisecontrolmetrics
@@ -223,7 +223,7 @@ services:
       retries: 30
 
   cruisecontrol:
-    image: ghcr.io/banzaicloud/cruise-control:2.5.86
+    image: ghcr.io/banzaicloud/cruise-control:2.5.101
     restart: unless-stopped
     hostname: cruisecontrol
     container_name: cruisecontrol

--- a/pkg/types/broker_stats.go
+++ b/pkg/types/broker_stats.go
@@ -108,7 +108,7 @@ type BrokerLoadStats struct {
 	BrokerState        BrokerState `json:"BrokerState"`
 	Broker             int32       `json:"Broker"`
 	NwOutRate          float64     `json:"NwOutRate"`
-	NumCore            int32       `json:"NumCore"`
+	NumCore            float64     `json:"NumCore"`
 	Host               string      `json:"Host"`
 	CPUPct             float64     `json:"CpuPct"`
 	Replicas           int32       `json:"Replicas"`

--- a/pkg/types/broker_stats.go
+++ b/pkg/types/broker_stats.go
@@ -88,7 +88,7 @@ func (s *BrokerState) UnmarshalText(data []byte) error {
 type HostLoadStats struct {
 	FollowerNwInRate   float64 `json:"FollowerNwInRate"`
 	NwOutRate          float64 `json:"NwOutRate"`
-	NumCore            int32   `json:"NumCore"`
+	NumCore            float64 `json:"NumCore"`
 	Host               string  `json:"Host"`
 	CPUPct             float64 `json:"CpuPct"`
 	Replicas           int32   `json:"Replicas"`


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no|
| Deprecations?   | yes |
| License         | Apache 2.0 |


### What's in this PR?
After release [2.5.94](https://github.com/linkedin/cruise-control/releases/tag/2.5.94), cruise control uses a double field for the number of cores used in host load and broker load responses instead of int ([PR-1839](https://github.com/linkedin/cruise-control/pull/1839)). The go-cruise-control client still uses an int field (see [here](https://github.com/banzaicloud/go-cruise-control/blob/b616ae1133669bc3cbc40369c693aab1a0764bc2/pkg/types/broker_stats.go#L91)).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Tested against Cruise Control version: x.y.z (if applicable)
- [x] User guide and development docs updated (if needed)
