### PR TITLE
fix: CI trigger for git tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - "[0-9].[0-9]+.[0-9]+*"
+      - "v[0-9].[0-9]+.[0-9]+*"
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
Fix regex used for triggering jobs for git tags.
