### PR TITLE
feat: allow setting Reason in Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,30 @@ import (
 )
 
 func main() {
-    // Initializing Cruise Control client with default configuration
-    cruisecontrol, err := client.NewDefaultClient()
-    if err != nil {
-        panic(err)
-    }
+	// Initializing Cruise Control client with default configuration
+	cruisecontrol, err := client.NewDefaultClient()
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30 * time.Second)                                                                                                                                  │    │
+	ctx, cancel := context.WithTimeout(context.Background(), 30 * time.Second)
 	defer cancel() 
-    
-    // Assembling the request using default values
-    req := api.StateRequestWithDefaults()
-    // Sending the request to the State API
-    resp, err := cruisecontrol.State(ctx, req)
-    if err != nil {
-        panic(err)
-    }
-    // Getting the state of the Executor
-    fmt.Println(resp.Result.ExecutorState.State)
+
+	// Optionally set request Reason to Context which will sent to Cruise Control as part of the HTTP request
+	ctx = client.ContextWithReason("example")
+
+	// Assembling the request using default values
+	req := api.StateRequestWithDefaults()
+
+	// Sending the request to the State API
+	resp, err := cruisecontrol.State(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	// Getting the state of the Executor
+	fmt.Println(resp.Result.ExecutorState.State)
 }
 ```
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -86,6 +86,10 @@ func (c Client) request(ctx context.Context, req interface{}, resp types.APIResp
 		WithContext(ctx),
 	}
 
+	if _, ok := req.(types.RequestReasoner); ok {
+		opts = append(opts, WithReasonFromContext(ctx))
+	}
+
 	httpResp, err := c.send(ctx, r, opts...)
 	if err != nil {
 		return err

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -27,6 +28,10 @@ import (
 
 	"github.com/banzaicloud/go-cruise-control/pkg/internal/encoder"
 )
+
+const reasonContextKey reasonContextKeyType = "CruiseControlRequestReason"
+
+type reasonContextKeyType string
 
 // RequestMarshaler is the interface implemented by types that can marshal themselves into valid http.Request
 type RequestMarshaler interface {
@@ -86,4 +91,17 @@ func marshal(v interface{}) (*http.Request, error) {
 	}
 
 	return r, nil
+}
+
+func ContextWithReason(ctx context.Context, reason string) context.Context {
+	return context.WithValue(ctx, reasonContextKey, reason)
+}
+
+func ReasonFromContext(ctx context.Context) (string, bool) {
+	if r := ctx.Value(reasonContextKey); r != nil {
+		if rr, ok := r.(string); ok {
+			return rr, true
+		}
+	}
+	return "", false
 }

--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -43,11 +43,21 @@ type GenericRequest struct {
 	DoAs string `param:"doAs,omitempty"`
 }
 
+// RequestReasoner is a dummy interface to help identifying APIRequests
+// which have the `Reason` field without the need for using reflection
+type RequestReasoner interface {
+	requestReason() string
+}
+
 type GenericRequestWithReason struct {
 	GenericRequest
 
 	// Reason for request
 	Reason string `param:"reason,omitempty"`
+}
+
+func (r GenericRequestWithReason) requestReason() string {
+	return r.Reason
 }
 
 type APIResponse interface {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
Cruise Control allow to set `reason` parameter as metadata in HTTP API requests in order to help distinguish which API request belongs to which high level operation executing on the client side. 

- [x] Implementation tested
- [x] Tested against Cruise Control version: 2.5.113 (if applicable)
- [x] User guide and development docs updated (if needed)
