### PR TITLE
feat: add possibility to set HTTP transport

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -137,8 +137,13 @@ func NewClient(opts *Config) (*Client, error) {
 	// 	Jar:       jar,
 	// 	Timeout:   0,
 	// }
+	transport := http.DefaultTransport
+	if opts.Transport != nil {
+		transport = opts.Transport
+	}
+
 	client.httpClient = &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: transport,
 	}
 
 	serverURL := DefaultServerURL

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"net/http"
 	"os"
 )
 
@@ -38,6 +39,7 @@ type Config struct {
 	Password    string
 	AccessToken string
 	UserAgent   string
+	Transport   http.RoundTripper
 }
 
 func (c *Config) ReadFromEnvironment() {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added possibility to set client's http transport, to be able to wrap requests, to add logging, for example.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
