### PR TITLE
refactor!: allow providing custom http.Client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -137,18 +137,17 @@ func NewClient(opts *Config) (*Client, error) {
 	// 	Jar:       jar,
 	// 	Timeout:   0,
 	// }
-	transport := http.DefaultTransport
-	if opts.Transport != nil {
-		transport = opts.Transport
+
+	client.httpClient = opts.HTTPClient
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{
+			Transport: http.DefaultTransport,
+		}
 	}
 
-	client.httpClient = &http.Client{
-		Transport: transport,
-	}
-
-	serverURL := DefaultServerURL
-	if opts.ServerURL != "" {
-		serverURL = opts.ServerURL
+	serverURL := opts.ServerURL
+	if serverURL == "" {
+		serverURL = DefaultServerURL
 	}
 	if !strings.HasSuffix(serverURL, "/") {
 		serverURL += "/"

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -39,7 +39,8 @@ type Config struct {
 	Password    string
 	AccessToken string
 	UserAgent   string
-	Transport   http.RoundTripper
+
+	HTTPClient *http.Client
 }
 
 func (c *Config) ReadFromEnvironment() {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | yes |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |

### What's in this PR?
Change `client.Config` to accept `http.Client` instead of `http.Transport` to provide more control over how HTTP communication is done via API client.

### Checklist

- [x] Implementation tested
- [x] Tested against Cruise Control version: x.y.z (if applicable)
- [x] User guide and development docs updated (if needed)
